### PR TITLE
Update version to use lodash 3.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-lodash",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An Angular module wrapper for lodash",
   "author": ["Rockabox <tech@rockabox.com> (http://www.rockabox.com)"],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-lodash",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An Angular module wrapper for lodash",
   "main": "build/ng-lodash.js",
   "scripts": {


### PR DESCRIPTION
PR merged https://github.com/rockabox/ng-lodash/pull/18 to use lodash latest (3.6.0) update ready for a release.